### PR TITLE
 Upgrade HashSet to use Go’s new iterator

### DIFF
--- a/container/set/hash_set.go
+++ b/container/set/hash_set.go
@@ -79,15 +79,12 @@ func (s HashSet[T]) DeleteFunc(pred func(T) bool) {
 	maps.DeleteFunc(s.m, func(k T, _ struct{}) bool { return pred(k) })
 }
 
-// Copy copies all key/value pairs in src adding them to dst.
-// When a key in src is already present in dst,
-// the value in dst will be overwritten by the value associated
-// with the key in src.
+// Copy copies all elements in src adding them to dst.
 func Copy[E comparable](dst, src HashSet[E]) {
 	maps.Copy(dst.m, src.m)
 }
 
-// IntersectionUpdate set, keeping only common elements between s and o
+// IntersectionUpdate set, keeping only common elements between s and other
 func (s HashSet[T]) IntersectionUpdate(other HashSet[T]) {
 	for v := range s.m {
 		if _, ok := other.m[v]; !ok {
@@ -96,7 +93,7 @@ func (s HashSet[T]) IntersectionUpdate(other HashSet[T]) {
 	}
 }
 
-// DifferenceUpdate the set, removing elements found in o
+// DifferenceUpdate the set, removing elements found in other
 func (s HashSet[T]) DifferenceUpdate(other HashSet[T]) {
 	s1, s2 := swapIfLess(s, other)
 	for v := range s1.m {
@@ -106,7 +103,8 @@ func (s HashSet[T]) DifferenceUpdate(other HashSet[T]) {
 	}
 }
 
-// SymmetricDifferenceUpdate, keeping elements found in either s or o but not in both
+// SymmetricDifferenceUpdate, keeping elements found in either s or other
+// , that is, values present in either s or other,but not in both
 func (s HashSet[T]) SymmetricDifferenceUpdate(other HashSet[T]) {
 	complement := make(map[T]struct{})
 	for v := range s.m {
@@ -122,7 +120,7 @@ func (s HashSet[T]) SymmetricDifferenceUpdate(other HashSet[T]) {
 	}
 }
 
-// IsDisjoint return true if sets s and o has no element in common.
+// IsDisjoint return true if sets s and other has no element in common.
 // Two sets are disjoint if and only if their intersection is the empty set
 func (s HashSet[T]) IsDisjoint(other HashSet[T]) bool {
 	s1, s2 := swapIfLess(s, other)
@@ -134,7 +132,7 @@ func (s HashSet[T]) IsDisjoint(other HashSet[T]) bool {
 	return true
 }
 
-// IsSubset test whether every element in s is also in o
+// IsSubset test whether every element in s is also in other
 func (s HashSet[T]) IsSubset(other HashSet[T]) bool {
 	if s.Len() > other.Len() {
 		return false
@@ -147,7 +145,7 @@ func (s HashSet[T]) IsSubset(other HashSet[T]) bool {
 	return true
 }
 
-// IsSuperset test whether every element in o is also in s
+// IsSuperset test whether every element in other is also in s
 func (s HashSet[T]) IsSuperset(other HashSet[T]) bool {
 	return other.IsSubset(s)
 }

--- a/container/set/hash_set.go
+++ b/container/set/hash_set.go
@@ -2,15 +2,14 @@
 package set
 
 import (
-	"iter"
 	"maps"
 )
 
-// Set is an unordered collection with unique elements.
+// HashSet is an unordered collection with unique elements.
 //
-// Set requires that the elements satisfy the comparable constraint.
+// HashSet requires that the elements satisfy the comparable constraint.
 // It support mathematical operations like union, difference, and symmetric difference
-type Set[T comparable] struct {
+type HashSet[T comparable] struct {
 	m map[T]struct{}
 }
 
@@ -18,45 +17,44 @@ type Set[T comparable] struct {
 //
 // The empty set is allocated with enough space to hold the
 // specified number of elements.
-func Make[T comparable]() Set[T] {
-	return Set[T]{
+func Make[T comparable]() HashSet[T] {
+	return HashSet[T]{
 		m: make(map[T]struct{}),
 	}
 }
 
 // Make creates an empty set with the specified capacity cap
-func MakeWithCapacity[T comparable](cap int) Set[T] {
-	return Set[T]{
+func MakeWithCapacity[T comparable](cap int) HashSet[T] {
+	return HashSet[T]{
 		m: make(map[T]struct{}, cap),
 	}
 }
 
 // Len returns the number of elements of set s
-func (s Set[T]) Len() int {
+func (s HashSet[T]) Len() int {
 	return len(s.m)
 }
 
-// All returns an iterator over keys from s.
-// The iteration order is not specified and is not guaranteed
-// to be the same from one call to the next.
-func (s Set[T]) All() iter.Seq[T] {
-	return maps.Keys(s.m)
-}
-
 // Copy return a copy of the set
-func (s Set[T]) Clone() Set[T] {
-	return Set[T]{
+func (s HashSet[T]) Clone() HashSet[T] {
+	return HashSet[T]{
 		m: maps.Clone(s.m),
 	}
 }
 
 // Clear removes all elements from the set
-func (s Set[T]) Clear() {
+func (s HashSet[T]) Clear() {
 	clear(s.m)
 }
 
+// Contains reports whether v is in s
+func (s HashSet[T]) Contains(v T) bool {
+	_, ok := s.m[v]
+	return ok
+}
+
 // FromSlice creates a new set using elements of xs
-func FromSlice[T comparable](xs []T) Set[T] {
+func FromSlice[T comparable](xs []T) HashSet[T] {
 	s := MakeWithCapacity[T](len(xs))
 	for _, v := range xs {
 		s.m[v] = struct{}{}
@@ -66,54 +64,41 @@ func FromSlice[T comparable](xs []T) Set[T] {
 
 // Add element v to the set s
 // if v is in s this has no effect
-func (s Set[T]) Add(v T) {
+func (s HashSet[T]) Add(v T) {
 	s.m[v] = struct{}{}
-}
-
-// Insert adds the elements from seq to m.
-// If a key in seq already exists in m, its value will be overwritten.
-func (s Set[T]) Insert(seq iter.Seq[T]) {
-	for v := range seq {
-		s.m[v] = struct{}{}
-	}
 }
 
 // Delete element v from the set s
 // If v not in s this has no effect
-func (s Set[T]) Delete(v T) {
+func (s HashSet[T]) Delete(v T) {
 	delete(s.m, v)
 }
 
 // DeleteFunc deletes all elements that satisfy the predicate pred from set
-func (s Set[T]) DeleteFunc(pred func(T) bool) {
+func (s HashSet[T]) DeleteFunc(pred func(T) bool) {
 	maps.DeleteFunc(s.m, func(k T, _ struct{}) bool { return pred(k) })
 }
 
-// Contains reports whether v is in s
-func (s Set[T]) Contains(v T) bool {
-	_, ok := s.m[v]
-	return ok
-}
-
-// Update set s, adding elements from set o
-func (s Set[T]) Update(o Set[T]) {
-	for v := range o.m {
-		s.m[v] = struct{}{}
-	}
+// Copy copies all key/value pairs in src adding them to dst.
+// When a key in src is already present in dst,
+// the value in dst will be overwritten by the value associated
+// with the key in src.
+func Copy[E comparable](dst, src HashSet[E]) {
+	maps.Copy(dst.m, src.m)
 }
 
 // IntersectionUpdate set, keeping only common elements between s and o
-func (s Set[T]) IntersectionUpdate(o Set[T]) {
+func (s HashSet[T]) IntersectionUpdate(other HashSet[T]) {
 	for v := range s.m {
-		if _, ok := o.m[v]; !ok {
+		if _, ok := other.m[v]; !ok {
 			delete(s.m, v)
 		}
 	}
 }
 
 // DifferenceUpdate the set, removing elements found in o
-func (s Set[T]) DifferenceUpdate(o Set[T]) {
-	s1, s2 := swapIfLess(s, o)
+func (s HashSet[T]) DifferenceUpdate(other HashSet[T]) {
+	s1, s2 := swapIfLess(s, other)
 	for v := range s1.m {
 		if _, ok := s2.m[v]; ok {
 			delete(s.m, v)
@@ -122,15 +107,15 @@ func (s Set[T]) DifferenceUpdate(o Set[T]) {
 }
 
 // SymmetricDifferenceUpdate, keeping elements found in either s or o but not in both
-func (s Set[T]) SymmetricDifferenceUpdate(o Set[T]) {
+func (s HashSet[T]) SymmetricDifferenceUpdate(other HashSet[T]) {
 	complement := make(map[T]struct{})
 	for v := range s.m {
-		if _, ok := o.m[v]; ok {
+		if _, ok := other.m[v]; ok {
 			complement[v] = struct{}{}
 			delete(s.m, v)
 		}
 	}
-	for v := range o.m {
+	for v := range other.m {
 		if _, ok := complement[v]; !ok {
 			s.Add(v)
 		}
@@ -139,8 +124,8 @@ func (s Set[T]) SymmetricDifferenceUpdate(o Set[T]) {
 
 // IsDisjoint return true if sets s and o has no element in common.
 // Two sets are disjoint if and only if their intersection is the empty set
-func (s Set[T]) IsDisjoint(o Set[T]) bool {
-	s1, s2 := swapIfLess(s, o)
+func (s HashSet[T]) IsDisjoint(other HashSet[T]) bool {
+	s1, s2 := swapIfLess(s, other)
 	for v := range s1.m {
 		if _, ok := s2.m[v]; ok {
 			return false
@@ -150,12 +135,12 @@ func (s Set[T]) IsDisjoint(o Set[T]) bool {
 }
 
 // IsSubset test whether every element in s is also in o
-func (s Set[T]) IsSubset(o Set[T]) bool {
-	if s.Len() > o.Len() {
+func (s HashSet[T]) IsSubset(other HashSet[T]) bool {
+	if s.Len() > other.Len() {
 		return false
 	}
 	for v := range s.m {
-		if _, ok := o.m[v]; !ok {
+		if _, ok := other.m[v]; !ok {
 			return false
 		}
 	}
@@ -163,25 +148,17 @@ func (s Set[T]) IsSubset(o Set[T]) bool {
 }
 
 // IsSuperset test whether every element in o is also in s
-func (s Set[T]) IsSuperset(o Set[T]) bool {
-	return o.IsSubset(s)
+func (s HashSet[T]) IsSuperset(other HashSet[T]) bool {
+	return other.IsSubset(s)
 }
 
 // Equal returns true if the contents are equal
-func (s Set[T]) Equal(o Set[T]) bool {
-	if len(s.m) != len(o.m) {
-		return false
-	}
-	for v := range s.m {
-		if _, ok := o.m[v]; !ok {
-			return false
-		}
-	}
-	return true
+func (s HashSet[T]) Equal(other HashSet[T]) bool {
+	return maps.Equal(s.m, other.m)
 }
 
 // Slice returns set elements as a slice
-func (s Set[T]) Slice() []T {
+func (s HashSet[T]) Slice() []T {
 	a := make([]T, len(s.m))
 	i := 0
 	for v := range s.m {
@@ -191,75 +168,10 @@ func (s Set[T]) Slice() []T {
 	return a
 }
 
-// Union returns a new set with elements from set s and o
-func Union[T comparable](s, o Set[T]) Set[T] {
-	u := make(map[T]struct{})
-	for v := range s.m {
-		u[v] = struct{}{}
-	}
-	for v := range o.m {
-		u[v] = struct{}{}
-	}
-	return Set[T]{m: u}
-}
-
-// Intersection returns new set with elements common to set s and o
-func Intersection[T comparable](s, o Set[T]) Set[T] {
-	intersect := Make[T]()
-	s, o = swapIfLess(s, o)
-	for v := range s.m {
-		if _, ok := o.m[v]; ok {
-			intersect.m[v] = struct{}{}
-		}
-	}
-	return intersect
-}
-
 // swapIfLess swap both sets if len(s) < len(o)
-func swapIfLess[T comparable](s, o Set[T]) (Set[T], Set[T]) {
+func swapIfLess[T comparable](s, o HashSet[T]) (HashSet[T], HashSet[T]) {
 	if len(s.m) < len(o.m) {
 		return s, o
 	}
 	return o, s
-}
-
-// Difference returns new set with elements in the set s that are not in o
-func Difference[T comparable](s, o Set[T]) iter.Seq[T] {
-	return func(yield func(T) bool) {
-		for v := range s.m {
-			if _, ok := o.m[v]; !ok {
-				if !yield(v) {
-					return
-				}
-			}
-		}
-	}
-}
-
-// SymmetricDifference returns new set with elements in either s or o but not both
-func SymmetricDifference[T comparable](s, o Set[T]) iter.Seq[T] {
-	return func(yield func(T) bool) {
-		for v := range s.m {
-			if _, ok := o.m[v]; !ok {
-				if !yield(v) {
-					return
-				}
-			}
-		}
-		for v := range o.m {
-			if _, ok := s.m[v]; !ok {
-				if !yield(v) {
-					return
-				}
-			}
-		}
-	}
-}
-
-func Construct[T comparable](seq iter.Seq[T]) Set[T] {
-	s := Make[T]()
-	for v := range seq {
-		s.Add(v)
-	}
-	return s
 }

--- a/container/set/hash_set.go
+++ b/container/set/hash_set.go
@@ -1,93 +1,112 @@
 // Package set implements hash sets of any comparable type
 package set
 
+import (
+	"iter"
+	"maps"
+)
+
 // Set is an unordered collection with unique elements.
 //
-// Set requires that the elements statisfy the comparable constraint.
-// It support mathematical operations like union, difference, and symmetric differce
-type Set[T comparable] map[T]struct{}
+// Set requires that the elements satisfy the comparable constraint.
+// It support mathematical operations like union, difference, and symmetric difference
+type Set[T comparable] struct {
+	m map[T]struct{}
+}
 
 // Make creates an empty set
 //
 // The empty set is allocated with enough space to hold the
 // specified number of elements.
 func Make[T comparable]() Set[T] {
-	return make(Set[T])
+	return Set[T]{
+		m: make(map[T]struct{}),
+	}
 }
 
 // Make creates an empty set with the specified capacity cap
 func MakeWithCapacity[T comparable](cap int) Set[T] {
-	return make(Set[T], cap)
+	return Set[T]{
+		m: make(map[T]struct{}, cap),
+	}
+}
+
+// Len returns the number of elements of set s
+func (s Set[T]) Len() int {
+	return len(s.m)
+}
+
+// All returns an iterator over keys from s.
+// The iteration order is not specified and is not guaranteed
+// to be the same from one call to the next.
+func (s Set[T]) All() iter.Seq[T] {
+	return maps.Keys(s.m)
+}
+
+// Copy return a copy of the set
+func (s Set[T]) Clone() Set[T] {
+	return Set[T]{
+		m: maps.Clone(s.m),
+	}
+}
+
+// Clear removes all elements from the set
+func (s Set[T]) Clear() {
+	clear(s.m)
 }
 
 // FromSlice creates a new set using elements of xs
 func FromSlice[T comparable](xs []T) Set[T] {
 	s := MakeWithCapacity[T](len(xs))
 	for _, v := range xs {
-		s[v] = struct{}{}
+		s.m[v] = struct{}{}
 	}
 	return s
-}
-
-// Len returns the number of elements of set s
-func (s Set[T]) Len() int {
-	return len(s)
 }
 
 // Add element v to the set s
 // if v is in s this has no effect
 func (s Set[T]) Add(v T) {
-	s[v] = struct{}{}
+	s.m[v] = struct{}{}
 }
 
-// InsertSlice inserts elements from slice xs
-func (s Set[T]) InsertSlice(xs []T) {
-	for _, v := range xs {
-		s[v] = struct{}{}
+// Insert adds the elements from seq to m.
+// If a key in seq already exists in m, its value will be overwritten.
+func (s Set[T]) Insert(seq iter.Seq[T]) {
+	for v := range seq {
+		s.m[v] = struct{}{}
 	}
 }
 
 // Delete element v from the set s
 // If v not in s this has no effect
 func (s Set[T]) Delete(v T) {
-	delete(s, v)
+	delete(s.m, v)
 }
 
-// DeleteIF deletes all elements that satisfy the predicate pred from set
-func (s Set[T]) DeleteIF(pred func(T) bool) {
-	for v := range s {
-		if pred(v) {
-			delete(s, v)
-		}
-	}
+// DeleteFunc deletes all elements that satisfy the predicate pred from set
+func (s Set[T]) DeleteFunc(pred func(T) bool) {
+	maps.DeleteFunc(s.m, func(k T, _ struct{}) bool { return pred(k) })
 }
 
 // Contains reports whether v is in s
 func (s Set[T]) Contains(v T) bool {
-	_, ok := s[v]
+	_, ok := s.m[v]
 	return ok
-}
-
-// Do applies function f to each element of s
-// It's ok for to call s.Delete(v)
-func (s Set[T]) Do(f func(T)) {
-	for v := range s {
-		f(v)
-	}
 }
 
 // Update set s, adding elements from set o
 func (s Set[T]) Update(o Set[T]) {
-	for v := range o {
-		s[v] = struct{}{}
+	for v := range o.m {
+		s.m[v] = struct{}{}
 	}
 }
 
 // IntersectionUpdate set, keeping only common elements between s and o
 func (s Set[T]) IntersectionUpdate(o Set[T]) {
-	for v := range s {
-		if _, ok := o[v]; !ok {
-			delete(s, v)
+	for v := range s.m {
+		if _, ok := o.m[v]; !ok {
+			delete(s.m, v)
 		}
 	}
 }
@@ -95,23 +114,23 @@ func (s Set[T]) IntersectionUpdate(o Set[T]) {
 // DifferenceUpdate the set, removing elements found in o
 func (s Set[T]) DifferenceUpdate(o Set[T]) {
 	s1, s2 := swapIfLess(s, o)
-	for v := range s1 {
-		if _, ok := s2[v]; ok {
-			delete(s, v)
+	for v := range s1.m {
+		if _, ok := s2.m[v]; ok {
+			delete(s.m, v)
 		}
 	}
 }
 
 // SymmetricDifferenceUpdate, keeping elements found in either s or o but not in both
 func (s Set[T]) SymmetricDifferenceUpdate(o Set[T]) {
-	complement := make(Set[T])
-	for v := range s {
-		if _, ok := o[v]; ok {
+	complement := make(map[T]struct{})
+	for v := range s.m {
+		if _, ok := o.m[v]; ok {
 			complement[v] = struct{}{}
-			delete(s, v)
+			delete(s.m, v)
 		}
 	}
-	for v := range o {
+	for v := range o.m {
 		if _, ok := complement[v]; !ok {
 			s.Add(v)
 		}
@@ -122,8 +141,8 @@ func (s Set[T]) SymmetricDifferenceUpdate(o Set[T]) {
 // Two sets are disjoint if and only if their intersection is the empty set
 func (s Set[T]) IsDisjoint(o Set[T]) bool {
 	s1, s2 := swapIfLess(s, o)
-	for v := range s1 {
-		if _, ok := s2[v]; ok {
+	for v := range s1.m {
+		if _, ok := s2.m[v]; ok {
 			return false
 		}
 	}
@@ -135,8 +154,8 @@ func (s Set[T]) IsSubset(o Set[T]) bool {
 	if s.Len() > o.Len() {
 		return false
 	}
-	for v := range s {
-		if _, ok := o[v]; !ok {
+	for v := range s.m {
+		if _, ok := o.m[v]; !ok {
 			return false
 		}
 	}
@@ -148,29 +167,13 @@ func (s Set[T]) IsSuperset(o Set[T]) bool {
 	return o.IsSubset(s)
 }
 
-// Copy return a copy of the set
-func (s Set[T]) Copy() Set[T] {
-	c := make(Set[T], len(s))
-	for v := range s {
-		c[v] = struct{}{}
-	}
-	return c
-}
-
-// Clear removes all elements from the set
-func (s Set[T]) Clear() {
-	for v := range s {
-		s.Delete(v)
-	}
-}
-
 // Equal returns true if the contents are equal
 func (s Set[T]) Equal(o Set[T]) bool {
-	if len(s) != len(o) {
+	if len(s.m) != len(o.m) {
 		return false
 	}
-	for v := range s {
-		if _, ok := o[v]; !ok {
+	for v := range s.m {
+		if _, ok := o.m[v]; !ok {
 			return false
 		}
 	}
@@ -179,9 +182,9 @@ func (s Set[T]) Equal(o Set[T]) bool {
 
 // Slice returns set elements as a slice
 func (s Set[T]) Slice() []T {
-	a := make([]T, len(s))
+	a := make([]T, len(s.m))
 	i := 0
-	for v := range s {
+	for v := range s.m {
 		a[i] = v
 		i++
 	}
@@ -190,23 +193,23 @@ func (s Set[T]) Slice() []T {
 
 // Union returns a new set with elements from set s and o
 func Union[T comparable](s, o Set[T]) Set[T] {
-	u := make(Set[T])
-	for v := range s {
+	u := make(map[T]struct{})
+	for v := range s.m {
 		u[v] = struct{}{}
 	}
-	for v := range o {
+	for v := range o.m {
 		u[v] = struct{}{}
 	}
-	return u
+	return Set[T]{m: u}
 }
 
 // Intersection returns new set with elements common to set s and o
 func Intersection[T comparable](s, o Set[T]) Set[T] {
-	intersect := make(Set[T])
+	intersect := Make[T]()
 	s, o = swapIfLess(s, o)
-	for v := range s {
-		if _, ok := o[v]; ok {
-			intersect[v] = struct{}{}
+	for v := range s.m {
+		if _, ok := o.m[v]; ok {
+			intersect.m[v] = struct{}{}
 		}
 	}
 	return intersect
@@ -214,35 +217,49 @@ func Intersection[T comparable](s, o Set[T]) Set[T] {
 
 // swapIfLess swap both sets if len(s) < len(o)
 func swapIfLess[T comparable](s, o Set[T]) (Set[T], Set[T]) {
-	if len(s) < len(o) {
+	if len(s.m) < len(o.m) {
 		return s, o
 	}
 	return o, s
 }
 
 // Difference returns new set with elements in the set s that are not in o
-func Difference[T comparable](s, o Set[T]) Set[T] {
-	diff := make(Set[T])
-	for v := range s {
-		if _, ok := o[v]; !ok {
-			diff[v] = struct{}{}
+func Difference[T comparable](s, o Set[T]) iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for v := range s.m {
+			if _, ok := o.m[v]; !ok {
+				if !yield(v) {
+					return
+				}
+			}
 		}
 	}
-	return diff
 }
 
 // SymmetricDifference returns new set with elements in either s or o but not both
-func SymmetricDifference[T comparable](s, o Set[T]) Set[T] {
-	diff := make(Set[T])
-	for v := range s {
-		if _, ok := o[v]; !ok {
-			diff[v] = struct{}{}
+func SymmetricDifference[T comparable](s, o Set[T]) iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for v := range s.m {
+			if _, ok := o.m[v]; !ok {
+				if !yield(v) {
+					return
+				}
+			}
+		}
+		for v := range o.m {
+			if _, ok := s.m[v]; !ok {
+				if !yield(v) {
+					return
+				}
+			}
 		}
 	}
-	for v := range o {
-		if _, ok := s[v]; !ok {
-			diff[v] = struct{}{}
-		}
+}
+
+func Construct[T comparable](seq iter.Seq[T]) Set[T] {
+	s := Make[T]()
+	for v := range seq {
+		s.Add(v)
 	}
-	return diff
+	return s
 }

--- a/container/set/hash_set_test.go
+++ b/container/set/hash_set_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func checkSetLen[T comparable](t *testing.T, s Set[T], len int) bool {
+func checkSetLen[T comparable](t *testing.T, s HashSet[T], len int) bool {
 	t.Helper()
 	if n := s.Len(); n != len {
 		t.Errorf("s.Len() = %d, want %d", n, len)
@@ -14,7 +14,7 @@ func checkSetLen[T comparable](t *testing.T, s Set[T], len int) bool {
 	return true
 }
 
-func checkSet[T comparable](t *testing.T, s Set[T], es []T) bool {
+func checkSet[T comparable](t *testing.T, s HashSet[T], es []T) bool {
 	t.Helper()
 	if !checkSetLen(t, s, len(es)) {
 		return false
@@ -35,10 +35,10 @@ func TestSetLen(t *testing.T) {
 	s.Add(1)
 	s.Add(2)
 	s.Add(1)
-	s.Insert(slices.Values([]int(nil)))
-	s.Insert(slices.Values([]int{}))
-	s.Insert(slices.Values([]int{1, 2, 3}))
-	s.Insert(slices.Values([]int{3, 4, 5}))
+	Insert(s, slices.Values([]int(nil)))
+	Insert(s, slices.Values([]int{}))
+	Insert(s, slices.Values([]int{1, 2, 3}))
+	Insert(s, slices.Values([]int{3, 4, 5}))
 	l := []int{1, 2, 3, 4, 5}
 	checkSet(t, s, l)
 	s.Delete(2)
@@ -46,12 +46,12 @@ func TestSetLen(t *testing.T) {
 	checkSet(t, s, []int{1, 3, 5})
 	s.DeleteFunc(func(v int) bool { return v&1 == 1 })
 	checkSetLen(t, s, 0)
-	s.Update(FromSlice[int](nil))
-	s.Update(FromSlice([]int{}))
-	s.Update(FromSlice([]int{1}))
-	s.Update(FromSlice([]int{1, 2, 3}))
-	s.Update(FromSlice([]int{4, 4}))
-	s.Update(FromSlice([]int{1, 4, 5}))
+	Copy(s, FromSlice[int](nil))
+	Copy(s, FromSlice([]int{}))
+	Copy(s, FromSlice([]int{1}))
+	Copy(s, FromSlice([]int{1, 2, 3}))
+	Copy(s, FromSlice([]int{4, 4}))
+	Copy(s, FromSlice([]int{1, 4, 5}))
 	checkSet(t, s, l)
 	s.Clear()
 	checkSetLen(t, s, 0)
@@ -60,11 +60,11 @@ func TestSetLen(t *testing.T) {
 func TestDisjoint(t *testing.T) {
 	emptySet := Make[int]()
 	tests := []struct {
-		xs, ys Set[int]
+		xs, ys HashSet[int]
 		want   bool
 	}{
 		{emptySet, emptySet, true},
-		{Set[int]{}, Set[int]{}, true},
+		{HashSet[int]{}, HashSet[int]{}, true},
 		{FromSlice([]int{1}), FromSlice([]int{2}), true},
 		{FromSlice([]int{1, 3}), FromSlice([]int{2, 4, 8}), true},
 		{FromSlice([]int{1, 2, 3, 7}), FromSlice([]int{-1, 2, 5}), false},
@@ -83,12 +83,12 @@ func TestDisjoint(t *testing.T) {
 func TestSubsetSuperSet(t *testing.T) {
 	xs := FromSlice([]int{1, 2, 3})
 	tests := []struct {
-		xs, ys     Set[int]
+		xs, ys     HashSet[int]
 		isSubset   bool
 		isSuperset bool
 	}{
 		{xs, xs, true, true},
-		{Set[int]{}, Set[int]{}, true, true},
+		{HashSet[int]{}, HashSet[int]{}, true, true},
 		{FromSlice([]int{1}), FromSlice([]int{1}), true, true},
 		{FromSlice([]int{}), FromSlice([]int{1}), true, false},
 		{FromSlice[int](nil), FromSlice([]int{1}), true, false},
@@ -147,8 +147,8 @@ func TestIntersection(t *testing.T) {
 	}
 	for _, tc := range tests {
 		s1, s2 := FromSlice(tc.xs), FromSlice(tc.ys)
-		checkSet(t, Intersection(s1, s2), tc.want)
-		checkSet(t, Intersection(s2, s1), tc.want)
+		checkSet(t, Collect(Intersection(s1, s2)), tc.want)
+		checkSet(t, Collect(Intersection(s2, s1)), tc.want)
 	}
 }
 
@@ -178,7 +178,7 @@ func TestDifference(t *testing.T) {
 	}
 	for _, tc := range tests {
 		s1, s2 := FromSlice(tc.xs), FromSlice(tc.ys)
-		checkSet(t, Construct(Difference(s1, s2)), tc.want)
+		checkSet(t, Collect(Difference(s1, s2)), tc.want)
 	}
 }
 
@@ -210,7 +210,7 @@ func TestSymmetricDifference(t *testing.T) {
 	}
 	for _, tc := range tests {
 		s1, s2 := FromSlice(tc.xs), FromSlice(tc.ys)
-		if !checkSet(t, Construct(SymmetricDifference(s1, s2)), tc.want) {
+		if !checkSet(t, Collect(SymmetricDifference(s1, s2)), tc.want) {
 			t.Errorf("%v.xor.%v got = %v want=%v", tc.xs, tc.ys, s1.Slice(), tc.want)
 		}
 	}
@@ -235,11 +235,11 @@ func TestUnion(t *testing.T) {
 	}
 	for _, tc := range tests {
 		s1, s2 := FromSlice(tc.xs), FromSlice(tc.ys)
-		s1.Update(s2)
+		Copy(s1, s2)
 		if !checkSet(t, s1, tc.want) {
 			t.Errorf("%v.union.%v got = %v want=%v", tc.xs, tc.ys, s1.Slice(), tc.want)
 		}
-		if !checkSet(t, Union(s1, s2), tc.want) {
+		if !checkSet(t, Collect(Union(s1, s2)), tc.want) {
 			t.Errorf("%v.union.%v got = %v want=%v", tc.xs, tc.ys, s1.Slice(), tc.want)
 		}
 	}
@@ -249,15 +249,15 @@ func TestEquality(t *testing.T) {
 	xs := FromSlice([]int{1, 2, 3})
 	emptySet := Make[int]()
 	tests := []struct {
-		xs, ys Set[int]
+		xs, ys HashSet[int]
 		want   bool
 	}{
 		{emptySet, emptySet, true},
 		{xs, xs, true},
 		{xs, xs.Clone(), true},
 		{xs, emptySet, false},
-		{xs, Set[int]{}, false},
-		{Set[int]{}, Set[int]{}, true},
+		{xs, HashSet[int]{}, false},
+		{HashSet[int]{}, HashSet[int]{}, true},
 		{FromSlice([]int{1}), FromSlice([]int{2}), false},
 		{FromSlice([]int{1, 3}), FromSlice([]int{2, 4}), false},
 		{FromSlice([]int{1, 2, 3}), xs, true},

--- a/container/set/hash_set_test.go
+++ b/container/set/hash_set_test.go
@@ -1,6 +1,7 @@
 package set
 
 import (
+	"slices"
 	"testing"
 )
 
@@ -34,16 +35,16 @@ func TestSetLen(t *testing.T) {
 	s.Add(1)
 	s.Add(2)
 	s.Add(1)
-	s.InsertSlice(nil)
-	s.InsertSlice([]int{})
-	s.InsertSlice([]int{1, 2, 3})
-	s.InsertSlice([]int{3, 4, 5})
+	s.Insert(slices.Values([]int(nil)))
+	s.Insert(slices.Values([]int{}))
+	s.Insert(slices.Values([]int{1, 2, 3}))
+	s.Insert(slices.Values([]int{3, 4, 5}))
 	l := []int{1, 2, 3, 4, 5}
 	checkSet(t, s, l)
 	s.Delete(2)
 	s.Delete(4)
 	checkSet(t, s, []int{1, 3, 5})
-	s.DeleteIF(func(v int) bool { return v&1 == 1 })
+	s.DeleteFunc(func(v int) bool { return v&1 == 1 })
 	checkSetLen(t, s, 0)
 	s.Update(FromSlice[int](nil))
 	s.Update(FromSlice([]int{}))
@@ -63,10 +64,9 @@ func TestDisjoint(t *testing.T) {
 		want   bool
 	}{
 		{emptySet, emptySet, true},
-		{nil, nil, true},
 		{Set[int]{}, Set[int]{}, true},
 		{FromSlice([]int{1}), FromSlice([]int{2}), true},
-		{FromSlice([]int{1, 3}), FromSlice([]int{2, 4,8}), true},
+		{FromSlice([]int{1, 3}), FromSlice([]int{2, 4, 8}), true},
 		{FromSlice([]int{1, 2, 3, 7}), FromSlice([]int{-1, 2, 5}), false},
 	}
 	for _, tc := range tests {
@@ -84,11 +84,10 @@ func TestSubsetSuperSet(t *testing.T) {
 	xs := FromSlice([]int{1, 2, 3})
 	tests := []struct {
 		xs, ys     Set[int]
-		issubset   bool
-		issuperset bool
+		isSubset   bool
+		isSuperset bool
 	}{
 		{xs, xs, true, true},
-		{nil, nil, true, true},
 		{Set[int]{}, Set[int]{}, true, true},
 		{FromSlice([]int{1}), FromSlice([]int{1}), true, true},
 		{FromSlice([]int{}), FromSlice([]int{1}), true, false},
@@ -100,20 +99,20 @@ func TestSubsetSuperSet(t *testing.T) {
 	}
 	for _, tc := range tests {
 		s1, s2 := tc.xs, tc.ys
-		if g := s1.IsSubset(s2); g != tc.issubset {
-			t.Errorf("%v.issubset(%v) got = %v want = %v", s1, s2, g, tc.issubset)
+		if g := s1.IsSubset(s2); g != tc.isSubset {
+			t.Errorf("%v.issubset(%v) got = %v want = %v", s1, s2, g, tc.isSubset)
 		}
-		if tc.issubset {
-			if g := s2.IsSuperset(s1); g != tc.issubset {
-				t.Errorf("%v.IsSuperset(%v) got = %v want = %v", s2, s1, g, tc.issubset)
+		if tc.isSubset {
+			if g := s2.IsSuperset(s1); g != tc.isSubset {
+				t.Errorf("%v.IsSuperset(%v) got = %v want = %v", s2, s1, g, tc.isSubset)
 			}
 		}
-		if g := s1.IsSuperset(s2); g != tc.issuperset {
-			t.Errorf("%v.IsSuperset(%v) got = %v want = %v", s1, s2, g, tc.issubset)
+		if g := s1.IsSuperset(s2); g != tc.isSuperset {
+			t.Errorf("%v.IsSuperset(%v) got = %v want = %v", s1, s2, g, tc.isSubset)
 		}
-		if tc.issuperset {
-			if g := s2.IsSubset(s1); g != tc.issubset {
-				t.Errorf("%v.IsSubset(%v) got = %v want = %v", s2, s1, g, tc.issubset)
+		if tc.isSuperset {
+			if g := s2.IsSubset(s1); g != tc.isSubset {
+				t.Errorf("%v.IsSubset(%v) got = %v want = %v", s2, s1, g, tc.isSubset)
 			}
 		}
 
@@ -155,7 +154,7 @@ func TestIntersection(t *testing.T) {
 
 func TestDifference(t *testing.T) {
 	xs := []int{3, 5, 11, 77}
-	ys := []int{1, 2, 6, 12, 43,-1}
+	ys := []int{1, 2, 6, 12, 43, -1}
 	zs := append(ys, xs...)
 	tests := []struct {
 		xs, ys []int
@@ -165,9 +164,8 @@ func TestDifference(t *testing.T) {
 		{xs, xs, nil},
 		{[]int{}, []int{}, []int{}},
 		{xs, []int{3}, xs[1:]},
-		{[]int{3},xs,[]int{}},
-		{[]int{3,8},xs,[]int{8}},
-
+		{[]int{3}, xs, []int{}},
+		{[]int{3, 8}, xs, []int{8}},
 
 		{xs, xs[:2], xs[2:]},
 		{zs, xs, ys},
@@ -180,7 +178,7 @@ func TestDifference(t *testing.T) {
 	}
 	for _, tc := range tests {
 		s1, s2 := FromSlice(tc.xs), FromSlice(tc.ys)
-		checkSet(t, Difference(s1, s2), tc.want)
+		checkSet(t, Construct(Difference(s1, s2)), tc.want)
 	}
 }
 
@@ -198,7 +196,7 @@ func TestSymmetricDifference(t *testing.T) {
 		// symmetric difference of disjoint is the same as the differnce
 		{zs, xs, ys},
 		{zs, ys, xs},
-		//symmetric difference of disjoint sets is the union
+		// symmetric difference of disjoint sets is the union
 		{xs, ys, zs},
 		//
 		{[]int{1, 3, 5, 9, 11}, []int{-2, 3, 9, 14, 22}, []int{-2, 1, 5, 11, 14, 22}},
@@ -212,7 +210,7 @@ func TestSymmetricDifference(t *testing.T) {
 	}
 	for _, tc := range tests {
 		s1, s2 := FromSlice(tc.xs), FromSlice(tc.ys)
-		if !checkSet(t, SymmetricDifference(s1, s2), tc.want) {
+		if !checkSet(t, Construct(SymmetricDifference(s1, s2)), tc.want) {
 			t.Errorf("%v.xor.%v got = %v want=%v", tc.xs, tc.ys, s1.Slice(), tc.want)
 		}
 	}
@@ -249,14 +247,15 @@ func TestUnion(t *testing.T) {
 
 func TestEquality(t *testing.T) {
 	xs := FromSlice([]int{1, 2, 3})
+	emptySet := Make[int]()
 	tests := []struct {
 		xs, ys Set[int]
 		want   bool
 	}{
-		{nil, nil, true},
+		{emptySet, emptySet, true},
 		{xs, xs, true},
-		{xs, xs.Copy(), true},
-		{xs, nil, false},
+		{xs, xs.Clone(), true},
+		{xs, emptySet, false},
 		{xs, Set[int]{}, false},
 		{Set[int]{}, Set[int]{}, true},
 		{FromSlice([]int{1}), FromSlice([]int{2}), false},
@@ -274,7 +273,9 @@ func TestEquality(t *testing.T) {
 func TestForEach(t *testing.T) {
 	xs := FromSlice([]int{1, 2, 3})
 	sum := 0
-	xs.Do(func(v int) { sum += v })
+	for v := range xs.All() {
+		sum += v
+	}
 	if sum != 6 {
 		t.Errorf("sum got %v want %v", sum, 6)
 	}

--- a/container/set/iter.go
+++ b/container/set/iter.go
@@ -1,0 +1,96 @@
+package set
+
+import (
+	"iter"
+	"maps"
+)
+
+// All returns an iterator over keys from s.
+// The iteration order is not specified and is not guaranteed
+// to be the same from one call to the next.
+func (s HashSet[T]) All() iter.Seq[T] {
+	return maps.Keys(s.m)
+}
+
+// Insert adds the elements from seq to m.
+// If a key in seq already exists in m, its value will be overwritten.
+func Insert[T comparable](s HashSet[T], seq iter.Seq[T]) {
+	for v := range seq {
+		s.m[v] = struct{}{}
+	}
+}
+
+// Union returns a new set with elements from set s and o
+func Union[T comparable](s, o HashSet[T]) iter.Seq[T] {
+	return func(yield func(T) bool) {
+		s, o = swapIfLess(s, o)
+		for v := range o.m {
+			if !yield(v) {
+				return
+			}
+		}
+
+		for v := range s.m {
+			if _, ok := o.m[v]; ok {
+				continue
+			}
+			if !yield(v) {
+				return
+			}
+		}
+	}
+}
+
+// Intersection returns new set with elements common to set s and o
+func Intersection[T comparable](s, o HashSet[T]) iter.Seq[T] {
+	return func(yield func(T) bool) {
+		s, o = swapIfLess(s, o)
+		for v := range s.m {
+			if _, ok := o.m[v]; ok {
+				if !yield(v) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// Difference returns new set with elements in the set s that are not in o
+func Difference[T comparable](s, o HashSet[T]) iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for v := range s.m {
+			if _, ok := o.m[v]; !ok {
+				if !yield(v) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// SymmetricDifference returns new set with elements in either s or o but not both
+func SymmetricDifference[T comparable](s, o HashSet[T]) iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for v := range s.m {
+			if _, ok := o.m[v]; !ok {
+				if !yield(v) {
+					return
+				}
+			}
+		}
+		for v := range o.m {
+			if _, ok := s.m[v]; !ok {
+				if !yield(v) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// Collect collects elements from seq into a new set and returns it.
+func Collect[T comparable](seq iter.Seq[T]) HashSet[T] {
+	s := Make[T]()
+	Insert(s, seq)
+	return s
+}

--- a/container/set/iter.go
+++ b/container/set/iter.go
@@ -5,14 +5,14 @@ import (
 	"maps"
 )
 
-// All returns an iterator over keys from s.
+// All returns an iterator over elements from s.
 // The iteration order is not specified and is not guaranteed
 // to be the same from one call to the next.
 func (s HashSet[T]) All() iter.Seq[T] {
 	return maps.Keys(s.m)
 }
 
-// Insert adds the elements from seq to m.
+// Insert adds the elements from seq to s.
 // If a key in seq already exists in m, its value will be overwritten.
 func Insert[T comparable](s HashSet[T], seq iter.Seq[T]) {
 	for v := range seq {
@@ -20,7 +20,9 @@ func Insert[T comparable](s HashSet[T], seq iter.Seq[T]) {
 	}
 }
 
-// Union returns a new set with elements from set s and o
+// Union visits the values representing the union
+//
+// that is, the values in s1 or s2, without duplicates.
 func Union[T comparable](s, o HashSet[T]) iter.Seq[T] {
 	return func(yield func(T) bool) {
 		s, o = swapIfLess(s, o)
@@ -41,12 +43,14 @@ func Union[T comparable](s, o HashSet[T]) iter.Seq[T] {
 	}
 }
 
-// Intersection returns new set with elements common to set s and o
-func Intersection[T comparable](s, o HashSet[T]) iter.Seq[T] {
+// Intersection visits the values representing the intersection
+//
+//	i.e., the values that are both in s1 and s2.
+func Intersection[T comparable](s1, s2 HashSet[T]) iter.Seq[T] {
 	return func(yield func(T) bool) {
-		s, o = swapIfLess(s, o)
-		for v := range s.m {
-			if _, ok := o.m[v]; ok {
+		s1, s2 = swapIfLess(s1, s2)
+		for v := range s1.m {
+			if _, ok := s2.m[v]; ok {
 				if !yield(v) {
 					return
 				}
@@ -55,12 +59,14 @@ func Intersection[T comparable](s, o HashSet[T]) iter.Seq[T] {
 	}
 }
 
-// Difference returns new set with elements in the set s that are not in o
-func Difference[T comparable](s, o HashSet[T]) iter.Seq[T] {
+//	Difference Iterates over the values in the difference between s1 and s2
+//
+// i.e., that is, values present in either s1 or s2, but not in both
+func Difference[T comparable](s1, s2 HashSet[T]) iter.Seq[T] {
 	return func(yield func(T) bool) {
-		for v := range s.m {
-			if _, ok := o.m[v]; !ok {
-				if !yield(v) {
+		for k := range s1.m {
+			if _, ok := s2.m[k]; !ok {
+				if !yield(k) {
 					return
 				}
 			}
@@ -68,19 +74,21 @@ func Difference[T comparable](s, o HashSet[T]) iter.Seq[T] {
 	}
 }
 
-// SymmetricDifference returns new set with elements in either s or o but not both
+// SymmetricDifference Iterates over the values in the symmetric difference between s1 and s2
+//
+// that is, values present in either s1 or s2, but not in both
 func SymmetricDifference[T comparable](s, o HashSet[T]) iter.Seq[T] {
 	return func(yield func(T) bool) {
-		for v := range s.m {
-			if _, ok := o.m[v]; !ok {
-				if !yield(v) {
+		for k := range s.m {
+			if _, ok := o.m[k]; !ok {
+				if !yield(k) {
 					return
 				}
 			}
 		}
-		for v := range o.m {
-			if _, ok := s.m[v]; !ok {
-				if !yield(v) {
+		for k := range o.m {
+			if _, ok := s.m[k]; !ok {
+				if !yield(k) {
 					return
 				}
 			}
@@ -88,7 +96,7 @@ func SymmetricDifference[T comparable](s, o HashSet[T]) iter.Seq[T] {
 	}
 }
 
-// Collect collects elements from seq into a new set and returns it.
+// Collect collects elements from seq into a new HashSet.
 func Collect[T comparable](seq iter.Seq[T]) HashSet[T] {
 	s := Make[T]()
 	Insert(s, seq)


### PR DESCRIPTION
- Upgrade HashSet to use Go’s new iterators
- Bump Go version from 1.18 to 1.23